### PR TITLE
Modernize the PyPI links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,13 +165,13 @@ License
 *Rsstail* is released under the terms of the `Revised BSD License`_.
 
 .. _rsstail:    http://www.vanheusden.com/rsstail/
-.. _feedstail:  http://pypi.python.org/pypi/feedstail/
+.. _feedstail:  https://pypi.org/project/feedstail/
 .. _theyoke:    http://github.com/mackers/theyoke/
 .. _wag:        http://github.com/knobe/wag/
 .. _ccze:       http://bonehunter.rulez.org/CCZE.html
 .. _clide:      http://suso.suso.org/xulu/Clide
 .. _colorize:   http://colorize.raszi.hu/
-.. _colorex:    http://pypi.python.org/pypi/colorex/
+.. _colorex:    https://pypi.org/project/colorex/
 .. _colout:     http://nojhan.github.io/colout/
 .. _multitail:  http://www.vanheusden.com/multitail/
 .. _feedparser: http://code.google.com/p/feedparser/
@@ -180,4 +180,4 @@ License
 
 .. _rsstail.sh:  https://raw.github.com/gvalkov/rsstail.py/master/etc/rsstail.sh
 .. _rsstail.zsh: https://raw.github.com/gvalkov/rsstail.py/master/etc/_rsstail
-.. _pypi:        https://pypi.python.org/pypi/rsstail
+.. _pypi:        https://pypi.org/project/rsstail/

--- a/scripts/pyzgen.sh
+++ b/scripts/pyzgen.sh
@@ -10,7 +10,7 @@ set -xeu
 DESTFILE="${1:-./rsstail.pyz}"
 DESTFILE=$(readlink -f "$DESTFILE")
 PYZEXCLUDE="\*__pycache__ \*.pyo \*.pyc feedparser-\*"
-FEEDPARSER_URL="https://pypi.python.org/packages/source/f/feedparser/feedparser-5.2.1.tar.gz"
+FEEDPARSER_URL="https://pypi.org/packages/source/f/feedparser/feedparser-5.2.1.tar.gz"
 
 #-----------------------------------------------------------------------------
 BUILDDIR=$(mktemp -d)


### PR DESCRIPTION
PyPI links have been using pypi.org for a few years and they redirect to HTTPS as well.