### PR TITLE
Fix reading of the Last-Modified timestamp

### DIFF
--- a/src/rsstail/main.py
+++ b/src/rsstail/main.py
@@ -343,7 +343,7 @@ def tick(feeds, opts, formatter, seen_id_hashes, iteration, stream=sys.stdout):
 
         # needed for fetching/showing only new entries on next run
         etag = getattr(feed, "etag", None)
-        last_mtime = getattr(feed.feed, "modified_parsed", None)
+        last_mtime = getattr(feed, "modified_parsed", None)
 
         feeds[url] = (etag, last_mtime, new_last_update)
 


### PR DESCRIPTION
In

    feed = feedparser.parse(url, etag=etag, modified=last_mtime)

if the modified parameter is provided it will be sent in the If-Modified-Since request header[1] so the value should come from last response's Last-Modified response header[2].

As far as I can tell there were two problems here:

1. The code tried to read feed.feed.modified_parsed which only exists if:

   a) We got HTTP 200 (an initial fetch or an updated feed fetch), the property is not there in case of HTTP 304 since there's no feed data to parse
   b) The feed data has a timestamp in a property recognized by feedparser, there's no guarantee such property exists
2. Even if feed.feed.modified_parsed is set it doesn't have to correspond to the exact Last-Modified timestamp anyway

I discovered this when testing rsstail.py with my with my feed reader testing tool[3] and with this patch the If-Modified-Since header is sent correctly, at least with feedparser 6.0.11.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
[2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified
[3] https://github.com/jstasiak/feed-reader-testbed