### PR TITLE
Imitate Firefox to get around overzealous reverse proxies

### DIFF
--- a/src/rsstail/main.py
+++ b/src/rsstail/main.py
@@ -294,7 +294,19 @@ def tick(feeds, opts, formatter, seen_id_hashes, iteration, stream=sys.stdout):
         log.debug("etag:  %s", etag)
         log.debug("mtime: %s", date_fmt(last_mtime))
 
-        feed = feedparser.parse(url, etag=etag, modified=last_mtime)
+        feed = feedparser.parse(
+            url,
+            etag=etag,
+            modified=last_mtime,
+
+            # A rudimentary web browser imitation to make some feeds behind overzealous
+            # reverse proxies work.
+            agent="Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0"
+,
+            request_headers={
+                "Sec-GPC": "1",
+            },
+        )
 
         if feed.bozo == 1:
             safeexc = (feedparser.CharacterEncodingOverride,)


### PR DESCRIPTION
There are some feeds where fetching them in a browser or for example in Vienna works fine but trying to access them with curl or rsstail (before this patch) results in HTTP 403.

For example:

    $ curl -v https://old.reddit.com/r/worldnews/.rss 2>&1 | rg "< HTTP"
    < HTTP/2 403

After a bit of trial and error I got this minimal set of headers that resolves the problem (neither of them works in isolation, they have to be provided together):

    $ curl -v \
        -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:139.0) Gecko/20100101 Firefox/139.0' \
        -H 'Sec-GPC: 1' https://old.reddit.com/r/worldnews/.rss 2>&1 | rg "< HTTP"
    < HTTP/2 200

It's a shame this has to be done since feeds are basically expected to be fetched by user bots/non-browsers/non-interactive software but it seems some systems are just misconfigured.

I also tested this solution with a Cloudflare-proxied website that has this problem and it also helps there.

Resolves: https://github.com/gvalkov/rsstail.py/issues/24